### PR TITLE
[mpegts] Drop provisional PSI PID registration on invalid section

### DIFF
--- a/lib/mpegts/mpegts/tsDemuxer.cpp
+++ b/lib/mpegts/mpegts/tsDemuxer.cpp
@@ -39,6 +39,7 @@ AVContext::AVContext(TSDemuxer* const demux, uint64_t pos, uint16_t channel)
   , payload(NULL)
   , payload_len(0)
   , packet(NULL)
+  , invalid_psi_section(false)
 {
   m_demux = demux;
   memset(av_buf, 0, sizeof(av_buf));
@@ -58,6 +59,7 @@ void AVContext::Reset(void)
   payload_unit_pos = 0;
   prev_payload_unit_pos = 0;
   packet = NULL;
+  invalid_psi_section = false;
 }
 
 uint16_t AVContext::GetPID() const
@@ -486,6 +488,11 @@ int AVContext::ProcessTSPacket()
           p.pid = this->pid;
           p.packet_type = PACKET_TYPE_PSI;
           p.continuity = continuity_counter;
+          // The heuristic above cannot distinguish a PSI table from arbitrary
+          // payload, e.g. a PES packet starts with the start code prefix
+          // 00 00 01, which reads as pointer_field 0 and table_id 0x00 (PAT).
+          // Keep the registration provisional until a section validates.
+          p.auto_registered = true;
           it = this->packets.insert(it, std::make_pair(this->pid, p));
         }
       }
@@ -558,7 +565,27 @@ int AVContext::ProcessTSPayload()
   switch (this->packet->packet_type)
   {
     case PACKET_TYPE_PSI:
+      this->invalid_psi_section = false;
       ret = parse_ts_psi();
+      // A provisionally registered PID that fails to deliver a valid section was
+      // never a PSI PID. Drop the registration, otherwise its payload keeps being
+      // parsed as PSI and discarded, and the elementary stream is lost for good
+      // (seen at HLS/TS segment boundaries on discontinuous live streams, where
+      // PES packets can reach the demuxer before the PAT/PMT of the new segment).
+      // A real PSI PID whose section was merely damaged in transit is registered
+      // again on the next section start.
+      if (this->packet && this->packet->auto_registered &&
+          (this->invalid_psi_section || ret == AVCONTEXT_TS_ERROR))
+      {
+        const uint16_t unregPid = this->packet->pid;
+        DBG(DEMUX_DBG_DEBUG, "%s: pid %.4x is not PSI, dropping provisional registration\n",
+            __FUNCTION__, unregPid);
+        this->packets.erase(unregPid);
+        this->packet = NULL;
+        // The failure was caused by our own registration, not by a stream error,
+        // so do not force the caller into a resync.
+        ret = AVCONTEXT_CONTINUE;
+      }
       break;
     case PACKET_TYPE_PES:
       ret = parse_ts_pes();
@@ -731,9 +758,14 @@ int AVContext::parse_ts_psi()
       DBG(DEMUX_DBG_DEBUG, "%s: bad PSI CRC on pid %.4x table_id %.2x; ignoring section\n",
           __FUNCTION__, this->packet->pid, this->packet->packet_table.table_id);
       this->packet->packet_table.Reset();
+      this->invalid_psi_section = true;
       return AVCONTEXT_CONTINUE;
     }
   }
+
+  // The section is intact, so this PID really does carry PSI and the
+  // registration is no longer provisional.
+  this->packet->auto_registered = false;
 
   const unsigned char* psi = this->packet->packet_table.buf;
   const unsigned char* end_psi = psi + this->packet->packet_table.len;

--- a/lib/mpegts/mpegts/tsDemuxer.h
+++ b/lib/mpegts/mpegts/tsDemuxer.h
@@ -118,6 +118,9 @@ namespace TSDemux
     const unsigned char* payload;
     size_t payload_len;
     Packet* packet;
+    // Set by parse_ts_psi() when an assembled section turns out not to be a
+    // valid PSI section, used to drop provisional PID registrations.
+    bool invalid_psi_section;
   };
 }
 

--- a/lib/mpegts/mpegts/tsPacket.h
+++ b/lib/mpegts/mpegts/tsPacket.h
@@ -32,6 +32,7 @@ namespace TSDemux
     , wait_unit_start(true)
     , has_stream_data(false)
     , streaming(false)
+    , auto_registered(false)
     , stream(NULL)
     , packet_table()
     {
@@ -59,6 +60,10 @@ namespace TSDemux
     bool wait_unit_start;
     bool has_stream_data;
     bool streaming;
+    // True when this PID was registered as PSI by the table_id heuristic instead
+    // of being announced by a PAT/PMT. Such a registration is provisional and is
+    // dropped again if the PID fails to deliver a valid section.
+    bool auto_registered;
     ElementaryStream* stream;
     TSTable packet_table;
   };


### PR DESCRIPTION
## Description

Commit 4ebb4ca ("[mpegts] Accept any PID number not only PAT with PID 0") replaced
the fixed `pid == 0` condition in `AVContext::ProcessTSPacket()` with a heuristic
that registers any unknown PID as `PACKET_TYPE_PSI` when the payload looks like it
starts with a `pointer_field` followed by `table_id` 0x00 (PAT) or 0x02 (PMT).

That heuristic has a false positive: a PES packet begins with the start code prefix
`00 00 01`, which reads as `pointer_field = 0x00` and therefore `table_id = 0x00`
(PAT). Any elementary stream PID whose first observed `payload_unit_start` packet
reaches the demuxer before the corresponding PAT/PMT is registered as PSI, and its
media payload is discarded from that point on.

This change keeps the heuristic but makes the registration provisional:

- `Packet` gains an `auto_registered` flag, set when a PID is registered by the
  heuristic rather than announced by a PAT/PMT.
- `parse_ts_psi()` clears the flag as soon as a section passes the CRC32 check
  added in be978e1, i.e. once the PID has proven it really carries PSI.
- `ProcessTSPayload()` drops the registration again if the section fails CRC
  validation or the parser returns `AVCONTEXT_TS_ERROR`, so the PID can be
  registered correctly by a later PMT.

The erase happens in `ProcessTSPayload()` rather than in `parse_ts_psi()` because
`this->packet` points into the `packets` map; `this->packet` is set to `NULL`
afterwards, which all accessors already handle. `AVCONTEXT_TS_ERROR` is normalised
to `AVCONTEXT_CONTINUE` in this path since the error was caused by our own bogus
registration and does not justify forcing the caller into a resync. A genuine PSI
PID whose section was merely damaged in transit is registered again on the next
section start, so the behaviour is self-healing.

## Motivation and context

Follow-up to be978e1 ("[mpegts] Validate PSI section CRC32 before parsing PAT/PMT"),
which fixed the crash caused by the same false positive but left the bogus PID
registration in place: on CRC failure the section buffer is reset and the function
returns, while the entry stays in `this->packets` as `PACKET_TYPE_PSI`.

The remaining symptom shows up on HLS/TS live streams with server-side ad insertion,
where every `#EXT-X-DISCONTINUITY` starts a separately muxed segment. When the video
PID is hijacked during the stream information scan of the first segment of a new
period, no SPS is parsed, `ES_h264` produces empty extra data, and Kodi rejects and
disables the video stream:

    error <general>: CVideoPlayerVideo::OpenStream(CDVDStreamInfo): Codec id 27 require extradata.
    warning <general>: OpenStream - Unsupported stream 3001. Stream disabled.
    debug <inputstream.adaptive>: EnableStream(3001: false)

Playback then continues audio-only until the decoder hits EOF and the stream is
reopened. This is the same failure class described in the commit message of
c9fc8ee, but it is not caused by undersized SPS/PPS buffers and therefore still
reproduces on 22.3.19-Piers.

Reverting 4ebb4ca also resolves it, but that would reintroduce the problem 4ebb4ca
was written for (streams whose PMT is not on PID 0 and that provide no PAT), so
this PR keeps the heuristic instead.

## How has this been tested?

Environment: Kodi 22.0-BETA1 master (Git:20260809-ad2b846cc6), macOS 26.6.1 on
Apple M3, debug build, FFmpeg 8.1.2-Kodi, inputstream.adaptive 22.3.19-Piers,
pvr.plutotv (Piers) on a German Pluto.tv channel — HLS/TS with AES-128 encrypted,
separately muxed ad segments and 6-7 periods per ad pod.

Runtime tests, counting occurrences in kodi.log:

| Build | Periods | `require extradata` / stream disabled |
| --- | --- | --- |
| 22.3.19-Piers unmodified | 8 | 1 |
| 22.3.19-Piers with 4ebb4ca reverted | 7 | 0 |
| 22.3.19-Piers with 4ebb4ca reverted, longer run | 21 (3 ad pods, ~1 h) | 0 |
| 22.3.19-Piers with this patch | 20 (3 ad pods, ~1 h) | 0 |

The revert of 4ebb4ca is listed only as a control to confirm the root cause; this
PR keeps the heuristic and achieves the same result.

Additionally exercised with a standalone harness driving the public `AVContext` API
over a synthetic transport stream that reproduces the ordering (PES packets of an
unregistered elementary stream PID arriving before the PAT/PMT of the segment). The
elementary stream is discovered correctly and the run is clean under
`-fsanitize=address,undefined`.

## Screenshots (if appropriate):

n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly

Note on code guidelines: `lib/mpegts/` is imported third-party code with its own
style; the changes follow the surrounding conventions rather than the Kodi guidelines.
Happy to adjust if you prefer otherwise.