### PR TITLE
[Session] Fix data race on m_periods in Kodi core chapter callbacks

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -295,6 +295,13 @@ void SESSION::CSession::InitializePeriod()
     // Complete the transition into the new period
     m_adaptiveTree->m_currentPeriod = m_adaptiveTree->m_nextPeriod;
     m_adaptiveTree->OnPeriodChange();
+    {
+      // Block manifest updates so the snapshot is built from a stable m_periods.
+      // This runs once per period change, not on the player callback path.
+      std::lock_guard<adaptive::AdaptiveTree::TreeUpdateThread> lckUpdTree(
+          m_adaptiveTree->GetTreeUpdMutex());
+      m_adaptiveTree->RefreshChaptersSnapshot();
+    }
   }
 
   // Clean to create new SESSION::STREAM objects. One for each AdaptationSet/Representation
@@ -679,6 +686,14 @@ bool SESSION::CSession::PrepareStream(CStream& stream)
     {
       if (!m_adaptiveTree->PrepareRepresentation(period, adp, repr))
         return false;
+
+      {
+        // PrepareRepresentation can process a child manifest (HLS) and by that add and
+        // remove periods. This runs after InitializePeriod, so refresh the snapshot.
+        std::lock_guard<adaptive::AdaptiveTree::TreeUpdateThread> lckUpdTree(
+            m_adaptiveTree->GetTreeUpdMutex());
+        m_adaptiveTree->RefreshChaptersSnapshot();
+      }
     }
   }
 
@@ -853,31 +868,42 @@ bool SESSION::CSession::SeekTime(double seekTime, bool& isError)
     seekTime = 0;
 
   // Check if we leave our current period
-  double chapterTime{0};
-  auto pi = m_adaptiveTree->m_periods.cbegin();
-
-  for (; pi != m_adaptiveTree->m_periods.cend(); pi++)
   {
-    chapterTime += double((*pi)->GetTlDuration()) / (*pi)->GetTimescale();
-    if (chapterTime > seekTime)
-      break;
+    // Block manifest updates, the update thread can add and remove periods at any time.
+    // Unlike the chapter callbacks this is not called on every player loop iteration,
+    // so blocking updates here is acceptable.
+    std::lock_guard<adaptive::AdaptiveTree::TreeUpdateThread> lckUpdTree(
+        m_adaptiveTree->GetTreeUpdMutex());
+
+    if (m_adaptiveTree->m_periods.empty())
+      return false;
+
+    double chapterTime{0};
+    auto pi = m_adaptiveTree->m_periods.cbegin();
+
+    for (; pi != m_adaptiveTree->m_periods.cend(); pi++)
+    {
+      chapterTime += double((*pi)->GetTlDuration()) / (*pi)->GetTimescale();
+      if (chapterTime > seekTime)
+        break;
+    }
+
+    if (pi == m_adaptiveTree->m_periods.cend())
+      --pi;
+
+    chapterTime -= double((*pi)->GetTlDuration()) / (*pi)->GetTimescale();
+
+    if ((*pi).get() != m_adaptiveTree->m_currentPeriod)
+    {
+      LOG::Log(LOGDEBUG, "SeekTime: seeking into new chapter: %d",
+               static_cast<int>((pi - m_adaptiveTree->m_periods.begin()) + 1));
+      SeekChapter(static_cast<int>(pi - m_adaptiveTree->m_periods.begin()) + 1);
+      m_chapterSeekTime = seekTime;
+      return true;
+    }
+
+    seekTime -= chapterTime;
   }
-
-  if (pi == m_adaptiveTree->m_periods.cend())
-    --pi;
-
-  chapterTime -= double((*pi)->GetTlDuration()) / (*pi)->GetTimescale();
-
-  if ((*pi).get() != m_adaptiveTree->m_currentPeriod)
-  {
-    LOG::Log(LOGDEBUG, "SeekTime: seeking into new chapter: %d",
-             static_cast<int>((pi - m_adaptiveTree->m_periods.begin()) + 1));
-    SeekChapter(static_cast<int>(pi - m_adaptiveTree->m_periods.begin()) + 1);
-    m_chapterSeekTime = seekTime;
-    return true;
-  }
-
-  seekTime -= chapterTime;
 
   if (m_adaptiveTree->IsLive())
   {
@@ -1127,18 +1153,11 @@ uint32_t SESSION::CSession::GetIncludedStreamMask() const
 
 int CSession::GetChapter() const
 {
-  if (m_adaptiveTree)
-  {
-    for (auto itPeriod = m_adaptiveTree->m_periods.cbegin();
-         itPeriod != m_adaptiveTree->m_periods.cend(); itPeriod++)
-    {
-      if ((*itPeriod).get() == m_adaptiveTree->m_currentPeriod)
-      {
-        return static_cast<int>(std::distance(m_adaptiveTree->m_periods.cbegin(), itPeriod)) + 1;
-      }
-    }
-  }
-  return 0;
+  if (!m_adaptiveTree)
+    return 0;
+
+  const int index = m_adaptiveTree->GetChaptersSnapshot()->currentIndex;
+  return index < 0 ? 0 : index + 1;
 }
 
 int SESSION::CSession::GetChapterCount() const
@@ -1146,7 +1165,7 @@ int SESSION::CSession::GetChapterCount() const
   if (!m_adaptiveTree)
     return 0;
 
-  return static_cast<int>(m_adaptiveTree->m_periods.size());
+  return static_cast<int>(m_adaptiveTree->GetChaptersSnapshot()->chapters.size());
 }
 
 const char* SESSION::CSession::GetChapterName(int number) const
@@ -1157,8 +1176,16 @@ const char* SESSION::CSession::GetChapterName(int number) const
   if (CSrvBroker::GetSettings().IsDebugVerbose() && m_adaptiveTree)
   {
     --number; // To convert chapter number to index
-    if (number >= 0 && number < static_cast<int>(m_adaptiveTree->m_periods.size()))
-      return m_adaptiveTree->m_periods[number]->GetId().c_str();
+
+    const auto snapshot = m_adaptiveTree->GetChaptersSnapshot();
+    const auto& chapters = snapshot->chapters;
+
+    if (number >= 0 && number < static_cast<int>(chapters.size()))
+    {
+      // Cached in a member to keep the returned pointer valid, see m_chapterName
+      m_chapterName = chapters[number].id;
+      return m_chapterName.c_str();
+    }
 
     return CHAPTER_NAME_UNKNOWN;
   }
@@ -1172,20 +1199,19 @@ int64_t SESSION::CSession::GetChapterPos(int number) const
 
   --number; // To convert chapter number to index
 
-  //! @todo: Fragile check, accessing to m_periods can potentially cause problems because
-  //! manifest updates can make changes (add/remove) to periods asynchronously.
-  //! An appropriate solution must be found, taking into account that these methods
-  //! can be called many times during playback. This issue must also be checked in
-  //! all other CSession methods on which Kodi core makes callbacks.
-  if (number < 0 || number >= static_cast<int>(m_adaptiveTree->m_periods.size()))
+  const auto snapshot = m_adaptiveTree->GetChaptersSnapshot();
+  const auto& chapters = snapshot->chapters;
+
+  if (number < 0 || number >= static_cast<int>(chapters.size()))
     return 0;
 
   int64_t sum{0};
 
   for (; number; --number)
   {
-    sum += (m_adaptiveTree->m_periods[number - 1]->GetTlDuration() * STREAM_TIME_BASE) /
-           m_adaptiveTree->m_periods[number - 1]->GetTimescale();
+    const auto& chapter = chapters[number - 1];
+    if (chapter.timescale > 0)
+      sum += (chapter.tlDuration * STREAM_TIME_BASE) / chapter.timescale;
   }
 
   return sum / STREAM_TIME_BASE;
@@ -1193,13 +1219,18 @@ int64_t SESSION::CSession::GetChapterPos(int number) const
 
 uint64_t SESSION::CSession::GetChapterStartTime() const
 {
+  if (!m_adaptiveTree)
+    return 0;
+
+  const auto snapshot = m_adaptiveTree->GetChaptersSnapshot();
+  const int currentIndex = snapshot->currentIndex;
+
   uint64_t start_time = 0;
-  for (std::unique_ptr<CPeriod>& p : m_adaptiveTree->m_periods)
+  for (int i = 0; i < currentIndex && i < static_cast<int>(snapshot->chapters.size()); ++i)
   {
-    if (p.get() == m_adaptiveTree->m_currentPeriod)
-      break;
-    else
-      start_time += (p->GetTlDuration() * STREAM_TIME_BASE) / p->GetTimescale();
+    const auto& chapter = snapshot->chapters[i];
+    if (chapter.timescale > 0)
+      start_time += (chapter.tlDuration * STREAM_TIME_BASE) / chapter.timescale;
   }
   return start_time;
 }
@@ -1221,6 +1252,11 @@ bool SESSION::CSession::SeekChapter(int number)
     return true;
 
   --number; // To convert chapter number to index
+
+  // Block manifest updates, the update thread can add and remove periods at any time
+  std::lock_guard<adaptive::AdaptiveTree::TreeUpdateThread> lckUpdTree(
+      m_adaptiveTree->GetTreeUpdMutex());
+
   if (number >= 0 && number < static_cast<int>(m_adaptiveTree->m_periods.size()) &&
       m_adaptiveTree->m_periods[number].get() != m_adaptiveTree->m_currentPeriod)
   {

--- a/src/Session.h
+++ b/src/Session.h
@@ -270,5 +270,13 @@ private:
   uint64_t m_chapterStartTime{0}; // In STREAM_TIME_BASE
   double m_chapterSeekTime{0.0}; // In seconds
   uint8_t m_mediaTypeMask{0};
+
+  //! @todo: the InputStream API method GetChapterName returns a "const char*" whose
+  //! lifetime the addon cannot control, so the value has to be cached here to keep the
+  //! returned pointer valid after the method returns. Kodi core copies the string right
+  //! away (CInputStreamAddon::GetChapterName), and the only two callers are on the GUI
+  //! thread, so this is safe in practice but remains a workaround for a bad API.
+  //! The API should be reworked to return a std::string, then this member can be removed.
+  mutable std::string m_chapterName;
 };
 } // namespace SESSION

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -802,6 +802,10 @@ bool adaptive::AdaptiveStream::ensureSegment()
       if (SecondsSinceUpdate() > 1)
       {
         m_tree->OnRequestSegments(current_period_, current_adp_, current_rep_);
+        // OnRequestSegments updates the manifest and by that can add and remove periods,
+        // refresh while updates are still blocked. Note that for these streams
+        // (HasManifestUpdatesSegs) the tree update thread does not perform any update.
+        m_tree->RefreshChaptersSnapshot();
         lastUpdated_ = std::chrono::system_clock::now();
       }
     }
@@ -920,6 +924,9 @@ bool adaptive::AdaptiveStream::ensureSegment()
               GenerateSidxSegments(newRep);
 
             m_tree->OnStreamChange(current_period_, current_adp_, prevRep, newRep);
+            // OnStreamChange can process a manifest and by that add and
+            // remove periods, refresh while updates are still blocked
+            m_tree->RefreshChaptersSnapshot();
             // Try aligning the segment to ensure that it exists on the changed representation
             m_tree->OnAlignSegment(current_period_, current_adp_, prevRep, newRep, queueSegment);
             // Do not allow quality change with only init segment (if used), ensure at least one segment

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -81,6 +81,37 @@ namespace adaptive
     m_updThread.Stop();
   }
 
+  std::shared_ptr<const AdaptiveTree::ChaptersSnapshot> AdaptiveTree::GetChaptersSnapshot() const
+  {
+    std::lock_guard<std::mutex> lock(m_chaptersSnapshotMutex);
+    return m_chaptersSnapshot;
+  }
+
+  void AdaptiveTree::RefreshChaptersSnapshot()
+  {
+    auto snapshot = std::make_shared<ChaptersSnapshot>();
+    snapshot->chapters.reserve(m_periods.size());
+
+    for (const auto& period : m_periods)
+    {
+      if (!period)
+        continue;
+
+      if (period.get() == m_currentPeriod)
+        snapshot->currentIndex = static_cast<int>(snapshot->chapters.size());
+
+      ChapterInfo info;
+      info.id = period->GetId();
+      info.tlDuration = period->GetTlDuration();
+      info.timescale = period->GetTimescale();
+
+      snapshot->chapters.emplace_back(std::move(info));
+    }
+
+    std::lock_guard<std::mutex> lock(m_chaptersSnapshotMutex);
+    m_chaptersSnapshot = std::move(snapshot);
+  }
+
   void AdaptiveTree::PostOpen()
   {
     SortTree();
@@ -94,6 +125,9 @@ namespace adaptive
       m_liveDelay = liveDelay;
     else if (m_liveDelay < 16)
       m_liveDelay = 16;
+
+    // Build the initial snapshot before the update thread can modify m_periods
+    RefreshChaptersSnapshot();
 
     StartUpdateThread();
 
@@ -439,6 +473,9 @@ namespace adaptive
         m_tree->m_updateInterval = PLAYLIST::NO_VALUE;
 
       m_tree->OnUpdateSegments();
+      // Periods may have been added or removed, refresh while updates are still
+      // blocked so readers never observe a half updated m_periods
+      m_tree->RefreshChaptersSnapshot();
     }
   }
 

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -327,6 +327,44 @@ public:
   TreeUpdateThread& GetTreeUpdMutex() { return m_updThread; };
 
   /*!
+   * \brief Immutable description of a period, used to serve the chapter
+   *        callbacks that Kodi core makes on the player thread.
+   */
+  struct ChapterInfo
+  {
+    std::string id;
+    uint64_t tlDuration{0};
+    uint64_t timescale{0};
+  };
+
+  /*!
+   * \brief Snapshot of the period layout at a given point in time.
+   *        m_periods must never be accessed directly to serve Kodi core
+   *        callbacks: the manifest update thread can add and remove periods
+   *        at any time, which invalidates both indices and element pointers.
+   */
+  struct ChaptersSnapshot
+  {
+    std::vector<ChapterInfo> chapters;
+    int currentIndex{-1}; //!< 0 based index of the period being played, -1 if unknown
+  };
+
+  /*!
+   * \brief Get the current chapter snapshot. Safe to call from any thread.
+   * \return A snapshot, never nullptr.
+   */
+  std::shared_ptr<const ChaptersSnapshot> GetChaptersSnapshot() const;
+
+  /*!
+   * \brief Rebuild the chapter snapshot from m_periods.
+   *        Must be called with manifest updates blocked, i.e. either from the
+   *        update thread itself or while holding GetTreeUpdMutex().
+   *        Every code path that adds or removes periods must call this, otherwise
+   *        the Kodi core chapter callbacks will keep serving stale data.
+   */
+  void RefreshChaptersSnapshot();
+
+  /*!
    * \brief Specifies if TTML subtitle time is relative to sample time.
    * \return True if relative to sample time, otherwise false.
    */
@@ -398,6 +436,12 @@ protected:
 
   bool m_isTTMLTimeRelative{false};
   bool m_isReqPrepareStream{false};
+
+private:
+  std::shared_ptr<const ChaptersSnapshot> m_chaptersSnapshot{
+      std::make_shared<const ChaptersSnapshot>()};
+  // Guards the m_chaptersSnapshot pointer only, never held while doing any work
+  mutable std::mutex m_chaptersSnapshotMutex;
 };
 
 } // namespace adaptive


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

`CSession::GetChapterPos()` and the other chapter accessors read
`m_adaptiveTree->m_periods` from the Kodi player thread without any
synchronisation, while the manifest update thread can add and remove periods at
the same time. This is the problem described by the existing `@todo` in
`GetChapterPos()`, which this PR removes.

The unsynchronised access was:

```cpp
sum += (m_adaptiveTree->m_periods[number - 1]->GetTlDuration() * STREAM_TIME_BASE) /
       m_adaptiveTree->m_periods[number - 1]->GetTimescale();
```

The update thread appends a period at every `#EXT-X-DISCONTINUITY`
(`HLSTree.cpp`, `m_periods.push_back(std::move(newPeriodPtr))`) and drops expired
ones (`m_periods.erase(...)`). When `push_back` reallocates the vector the
`unique_ptr` elements are move constructed into the new buffer, so a concurrent
reader can observe a null element. The bounds check above the access is racy as
well, since `size()` is read separately from the element access.

The manifest update lock (`GetTreeUpdMutex()`) is taken in `AdaptiveStream.cpp`
and `HLSTree.cpp`, but nowhere in `Session.cpp`.

This change serves the callbacks from an immutable snapshot instead:

- `AdaptiveTree` gains `ChaptersSnapshot` (period id, `tlDuration`, `timescale`,
  plus the index of the current period) held as a
  `std::shared_ptr<const ChaptersSnapshot>`.
- `RefreshChaptersSnapshot()` rebuilds it and is called from `PostOpen()` before
  the update thread starts, from the update worker right after
  `OnUpdateSegments()`, and from `CSession::InitializePeriod()` after a period
  change.
- All five accessors (`GetChapter()`, `GetChapterCount()`, `GetChapterName()`,
  `GetChapterPos()`, `GetChapterStartTime()`) now read only the snapshot and no
  longer touch `m_periods`.

The reader side copies the `shared_ptr` under a mutex that is never held while
doing any work, which keeps the player callback path cheap. Simply taking the
update lock in the accessors is not viable: `TreeUpdateThread::lock()` is
`Pause()` and can block on a manifest download, and these callbacks run on every
player loop iteration — the second half of the `@todo`.

`STREAM_TIME_BASE` scaling stays in `Session.cpp` because the constant comes from
the Kodi headers and is not necessarily visible in `AdaptiveTree.cpp`. The
arithmetic is otherwise unchanged, with an added guard against `timescale == 0`
that did not exist before. `GetChapterStartTime()` previously iterated
`m_periods` with no null or bounds check at all.

Two points I am not sure about and would like your opinion on:

- `InitializePeriod()` takes `std::lock_guard<TreeUpdateThread>` to rebuild the
  snapshot from a stable `m_periods`. This runs once per period change on the
  demux thread rather than on the callback path, and follows the pattern already
  used in `AdaptiveStream.cpp`, but it is the riskiest part of the change.
- `GetChapterName()` returns a `const char*`, so the session has to keep the
  snapshot alive across the return. That is a workaround for the signature rather
  than a clean solution, and I am happy to change the approach if you prefer.

## Motivation and context

Reproducible SIGSEGV on Android when a live HLS stream with server-side ad
insertion enters an ad break. Tombstone (NVIDIA Shield, Android 11, arm64):

```
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x178
Cause: null pointer dereference
#00 pc 000000000012f698  libinputstream.adaptive.so
#01 pc 00000000023cd818  libkodi.so (non-virtual thunk to CInputStreamAddon::GetChapterPos(int)+28)
#02 pc 000000000242a980  libkodi.so (CVideoPlayer::UpdatePlayState(double)+1416)
#03 pc 000000000242b700  libkodi.so (CVideoPlayer::Process()+432)
```

The null dereference matches a reader observing a moved-from `unique_ptr` during
a `push_back` reallocation.

The kodi.log shows the period switch at 09:14:45.220 and the crash at
09:14:49.538. In between, `CDVDVideoCodecAndroidMediaCodec::Open - InstanceGuard
locked` delays the video codec reopen by about 4 seconds, so the reopen coincides
with a manifest update. The same stream on macOS shows an equivalent
VideoToolbox delay of 3.3–4.0 s across 20 period switches and does not crash —
the race is timing dependent and only lost on the slower device.

Unrelated to #2095; the crash occurs both with and without that patch.

## How has this been tested?

Quick runtime-test on macOS, no regressions found.
Extended runtime-test on Android (on the machine I encountered the crashes): tested more then 3 hours playback in row, at least 6 ad breaks, no crashes occurred. No regressions found.

## Screenshots (if appropriate):

n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
