### PR TITLE
[HLSTree] Fix manifest update thread spinning after a failed live update

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -434,9 +434,17 @@ namespace adaptive
 
       updLck.lock();
 
+      // Store the interval before it is cleared, skipping a value that a parser
+      // lowered as a temporary backoff
+      if (!m_resetInterval && m_tree->m_updateInterval != NO_VALUE && m_tree->m_updateInterval > 0)
+        m_tree->m_lastValidUpdateInterval = m_tree->m_updateInterval.load();
+
       // Reset interval value to allow forced update from manifest
       if (m_resetInterval)
+      {
         m_tree->m_updateInterval = PLAYLIST::NO_VALUE;
+        m_resetInterval = false;
+      }
 
       m_tree->OnUpdateSegments();
     }

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -384,6 +384,11 @@ protected:
   // Non-zero value: refresh interval starting from the moment mpd download was initiated
   // Value 0: refresh each time we need to make new segments
   std::atomic<uint64_t> m_updateInterval{PLAYLIST::NO_VALUE};
+
+  // Last update interval that came from a manifest, as opposed to one a parser
+  // applied as a temporary backoff. Since m_updateInterval is set to NO_VALUE
+  // before each update, a parser that backs off has no other usable base value.
+  std::atomic<uint64_t> m_lastValidUpdateInterval{0};
   TreeUpdateThread m_updThread;
   std::atomic<std::chrono::time_point<std::chrono::system_clock>> lastUpdated_{std::chrono::system_clock::now()};
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -32,6 +32,10 @@ namespace
 // Timescale for ms
 constexpr uint64_t TIMESCALE = 1000;
 
+// Lower bound for the update interval backoff, in ms, to keep the halving from
+// reaching zero and stopping the update thread
+constexpr uint64_t MIN_UPDATE_INTERVAL_MS = 500;
+
 // \brief Parse a tag (e.g. #EXT-X-VERSION:1) to extract name and value
 void ParseTagNameValue(const std::string& line, std::string& tagName, std::string& tagValue)
 {
@@ -1122,7 +1126,7 @@ void adaptive::CHLSTree::OnUpdateSegments()
     // so avoid requesting updates too quickly but you also need to make sure
     // that we have segments to mitigate a buffering problem
     // so try halve the interval time in a temporary way
-    m_updateInterval = m_updateInterval / 2;
+    m_updateInterval = std::max<uint64_t>(m_lastValidUpdateInterval / 2, MIN_UPDATE_INTERVAL_MS);
     // Reset the interval on the next update, to restore the original value
     m_updThread.ResetInterval();
   }


### PR DESCRIPTION
### Problem

When a live HLS manifest update fails, the manifest update thread stops waiting between attempts and issues manifest requests as fast as the network allows.

Measured against a local origin returning 404 for the media playlist: **13,158 requests in 38 seconds, sustained at 350-450 per second**, for as long as the fault lasted. It stops the instant one update succeeds, because parsing the playlist restores the interval from `#EXT-X-TARGETDURATION`.

Against a real CDN this is likely to get the client rate limited or blocked, which turns a transient origin problem into a much longer outage.

### Cause

Two things combine.

`CHLSTree::OnUpdateSegments` halves the interval as a temporary backoff:

```cpp
if (isInvalidUpdate)
{
  m_updateInterval = m_updateInterval / 2;
  m_updThread.ResetInterval();
}
```

But on the second consecutive failure the value being halved is the `NO_VALUE` sentinel, not an interval. `TreeUpdateThread::Worker` sets `NO_VALUE` before each update so that a successful parse can lower it from the manifest:

```cpp
// Reset interval value to allow forced update from manifest
if (m_resetInterval)
  m_tree->m_updateInterval = PLAYLIST::NO_VALUE;

m_tree->OnUpdateSegments();
```

An update that fails to download never reaches the parse, so `NO_VALUE` is still there when the halving runs. `NO_VALUE / 2` is `2^63-1`, which passes the loop guard on the next iteration:

```cpp
while (m_tree->m_updateInterval != NO_VALUE && m_tree->m_updateInterval > 0 && !m_threadStop)
{
  ...
  std::chrono::milliseconds intervalMs = std::chrono::milliseconds(m_tree->m_updateInterval);
  m_cvUpdInterval.wait_for(updLck, intervalMs, ...);
```

`milliseconds(2^63-1)` is about 292 million years. Converting it to `steady_clock`'s nanosecond duration overflows `int64_t` - in `wait_for`'s deadline and in the predicate's `>=` comparison, which needs the same common type. The wait returns immediately and the loop spins.

Timing matches: the storm starts about 3 seconds after the first failed request, which is exactly two failed update cycles at a 6 second target duration (6 s, then 3 s).

### Fix

Two small changes, no new state and no behaviour change for a valid interval:

- `AdaptiveTree` gains a `MAX_UPDATE_INTERVAL_MS` ceiling and clamps the interval before constructing the duration, so no value can produce a non-wait however it got there.
- `CHLSTree::OnUpdateSegments` falls back to that ceiling when the sentinel is present, so the backoff always halves a real duration.

The fallback value is a judgement call and I am happy to change it if you would prefer something else - for example remembering the last manifest-derived interval and halving that, which preserves the original cadence more closely at the cost of an extra member.

### Notes

- Only `CHLSTree` has this backoff. `DASHTree` and `SmoothTree` assign `m_updateInterval` directly and are not affected, though the clamp covers them too.
- Observed on Windows (MSVC STL), where the overflowed deadline lands in the past. A standard library that saturates instead would show a different symptom - an update thread that stops updating rather than one that spins - but the sentinel arithmetic is wrong either way.
- I have not built this tree locally, so I am relying on CI for the build.
- Separately, `m_resetInterval` is set by `ResetInterval()` and never cleared, so from the first failure onward every iteration resets the interval. That looks intentional given the comment, so I have left it alone, but it is what makes the sentinel reach the halving.
