### PR TITLE
Support Kodi VFS resources

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -15,7 +15,6 @@
 #include "Chooser.h"
 #include "CompKodiProps.h"
 #include "SrvBroker.h"
-#include "utils/StringUtils.h"
 #include "utils/CurlUtils.h"
 #include "utils/UrlUtils.h"
 #include "utils/log.h"
@@ -107,6 +106,13 @@ bool adaptive::AdaptiveStream::DownloadImpl(const DownloadInfo& downloadInfo,
 
   CURL::CUrl curl{url};
   curl.AddHeaders(headers);
+  if (downloadInfo.m_rangeBegin != NO_VALUE)
+  {
+    if (downloadInfo.m_rangeEnd == NO_VALUE)
+      curl.SetByteRange(downloadInfo.m_rangeBegin);
+    else
+      curl.SetByteRange(downloadInfo.m_rangeBegin, downloadInfo.m_rangeEnd);
+  }
 
   int statusCode = curl.Open();
 
@@ -118,10 +124,28 @@ bool adaptive::AdaptiveStream::DownloadImpl(const DownloadInfo& downloadInfo,
   else // Start the download
   {
     CURL::ReadStatus downloadStatus = CURL::ReadStatus::CHUNK_READ;
-    bool isChunked = curl.IsChunked();
+    std::vector<uint8_t> pendingData;
+
+    const auto appendSegmentData = [&](const std::vector<uint8_t>& data, bool isLastChunk) {
+      // The status can be changed e.g. by a video seek or stop.
+      if (thread_data_->State() == THREADDATA::ThState::STOPPED)
+        return false;
+
+      std::vector<uint8_t> bufferOutput;
+      m_tree->OnDataArrived(downloadInfo.m_segmentBuffer->segment.m_number,
+                            downloadInfo.m_segmentBuffer->segment.AESKeyInfo(), m_decrypterIv,
+                            data.data(), data.size(), bufferOutput,
+                            downloadInfo.m_segmentBuffer->BufferSize(), isLastChunk);
+      downloadInfo.m_segmentBuffer->AppendBuffer(bufferOutput);
+      thread_data_->cvRW.notify_all();
+      return true;
+    };
 
     while (downloadStatus == CURL::ReadStatus::CHUNK_READ)
     {
+      if (!downloadData && thread_data_->State() == THREADDATA::ThState::STOPPED)
+        break;
+
       std::vector<uint8_t> bufferData(CURL::BUFFER_SIZE_32);
       size_t bytesRead{0};
 
@@ -131,31 +155,21 @@ bool adaptive::AdaptiveStream::DownloadImpl(const DownloadInfo& downloadInfo,
       {
         if (downloadData) // Write the data in to the string
         {
-          downloadData->insert(downloadData->end(), bufferData.begin(), bufferData.end());
+          downloadData->insert(downloadData->end(), bufferData.begin(),
+                               bufferData.begin() + bytesRead);
         }
         else // Write the data to the segment buffer
         {
-          // We only set lastChunk to true in the case of non-chunked transfers, the
-          // current structure does not allow for knowing the file has finished for
-          // chunked transfers here - IsEOF() will return true while doing chunked transfers
-          bool isLastChunk = !isChunked && curl.IsEOF();
-
-          // The status can be changed after waiting for the lock_guard e.g. video seek/stop
-          if (thread_data_->State() == THREADDATA::ThState::STOPPED)
+          if (!pendingData.empty() && !appendSegmentData(pendingData, false))
             break;
-
-          std::vector<uint8_t> bufferOutput;
-
-          m_tree->OnDataArrived(downloadInfo.m_segmentBuffer->segment.m_number,
-                                downloadInfo.m_segmentBuffer->segment.AESKeyInfo(), m_decrypterIv,
-                                bufferData.data(), bytesRead, bufferOutput,
-                                downloadInfo.m_segmentBuffer->BufferSize(), isLastChunk);
-
-          downloadInfo.m_segmentBuffer->AppendBuffer(bufferOutput);
-          thread_data_->cvRW.notify_all();
+          pendingData.assign(bufferData.begin(), bufferData.begin() + bytesRead);
         }
       }
     }
+
+    if (downloadStatus == CURL::ReadStatus::IS_EOF && !downloadData && !pendingData.empty() &&
+        !appendSegmentData(pendingData, true))
+      downloadStatus = CURL::ReadStatus::CHUNK_READ;
 
     if (downloadStatus == CURL::ReadStatus::ERROR)
     {
@@ -241,20 +255,10 @@ bool adaptive::AdaptiveStream::PrepareDownload(const PLAYLIST::CRepresentation* 
 
   if (seg.HasByteRange())
   {
-    std::string rangeHeader;
-    uint64_t fileOffset = seg.IsInitialization() ? 0 : m_segmentFileOffset;
-
+    const uint64_t fileOffset = seg.IsInitialization() ? 0 : m_segmentFileOffset;
+    downloadInfo.m_rangeBegin = seg.range_begin_ + fileOffset;
     if (seg.range_end_ != NO_VALUE)
-    {
-      rangeHeader = STRING::Format("bytes=%llu-%llu", seg.range_begin_ + fileOffset,
-                                   seg.range_end_ + fileOffset);
-    }
-    else
-    {
-      rangeHeader = STRING::Format("bytes=%llu-", seg.range_begin_ + fileOffset);
-    }
-
-    downloadInfo.m_addHeaders["Range"] = rangeHeader;
+      downloadInfo.m_rangeEnd = seg.range_end_ + fileOffset;
   }
 
   downloadInfo.m_url = streamUrl;

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -160,6 +160,8 @@ enum class EVENT_TYPE
     {
       std::string m_url;
       std::map<std::string, std::string> m_addHeaders; // Additional headers
+      uint64_t m_rangeBegin{PLAYLIST::NO_VALUE};
+      uint64_t m_rangeEnd{PLAYLIST::NO_VALUE};
       ADP::SegmentBuffer* m_segmentBuffer{nullptr}; // Optional, the segment buffer where to store the data
     };
 

--- a/src/common/ChooserDefault.cpp
+++ b/src/common/ChooserDefault.cpp
@@ -108,6 +108,9 @@ void CRepresentationChooserDefault::PostInit()
         "[Repr. chooser] The initial bandwidth cannot be determined due to download speed at 0. "
         "Fallback to default user setting.");
     m_bandwidthCurrent = std::max(m_bandwidthInit, m_bandwidthMin);
+    m_bandwidthCurrentLimited = m_bandwidthCurrent;
+    if (m_bandwidthMax > 0 && m_bandwidthCurrentLimited > m_bandwidthMax)
+      m_bandwidthCurrentLimited = m_bandwidthMax;
   }
 
   LOG::Log(LOGDEBUG,
@@ -159,6 +162,9 @@ void CRepresentationChooserDefault::RefreshResolution()
 
 void CRepresentationChooserDefault::SetDownloadSpeed(const double speed)
 {
+  if (speed <= 0)
+    return;
+
   m_downloadSpeedChron.push_back(speed);
 
   // Calculate the average speed of last 10 download speeds

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_definitions(-DINPUTSTREAM_TEST_BUILD)
 
 add_executable(${BINARY}
     TestMain.cpp
+    TestChooser.cpp
     TestCurlUtils.cpp
     TestDASHTree.cpp
     TestHLSTree.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(${BINARY}
     TestHLSTree.cpp
     TestSmoothTree.cpp
     TestHelper.cpp
+    TestUrlUtils.cpp
     TestUtils.cpp
     ../aes_decrypter.cpp
     ../decrypters/Helpers.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_definitions(-DINPUTSTREAM_TEST_BUILD)
 
 add_executable(${BINARY}
     TestMain.cpp
+    TestCurlUtils.cpp
     TestDASHTree.cpp
     TestHLSTree.cpp
     TestSmoothTree.cpp

--- a/src/test/KodiStubs.h
+++ b/src/test/KodiStubs.h
@@ -10,7 +10,9 @@
 
  // Kodi interface stubs
 
+#include <algorithm>
 #include <cstdint>
+#include <cstdio>
 #include <string>
 #include <vector>
 #include <map>
@@ -147,6 +149,32 @@ struct VFSDirEntry
 
 namespace vfs
 {
+struct CFileTestState
+{
+  bool forceUnknownLength{false};
+  bool failSeek{false};
+  bool curlCreateResult{false};
+  bool curlOpenResult{false};
+  bool curlCreateCalled{false};
+  bool curlOpenCalled{false};
+  bool openFileCalled{false};
+  size_t readCalls{0};
+  std::string responseProtocol;
+  std::string effectiveUrl;
+  std::map<std::string, std::string> curlHeaders;
+};
+
+inline CFileTestState& GetCFileTestState()
+{
+  static CFileTestState state;
+  return state;
+}
+
+inline void ResetCFileTestState()
+{
+  GetCFileTestState() = {};
+}
+
 class ATTR_DLL_LOCAL CDirEntry
 {
 public:
@@ -198,22 +226,63 @@ class CFile
 public:
   CFile() = default;
   virtual ~CFile() { Close(); }
-  bool OpenFile(const std::string& filename, unsigned int flags = 0) { return false; }
+  bool OpenFile(const std::string& filename, unsigned int flags = 0)
+  {
+    auto& state = GetCFileTestState();
+    state.openFileCalled = true;
+    Close();
+    std::string path{filename};
+    if (path.starts_with("file://"))
+      path.erase(0, 7);
+#ifdef _WIN32
+    if (path.size() > 2 && path.front() == '/' && path[2] == ':')
+      path.erase(0, 1);
+    std::replace(path.begin(), path.end(), '/', '\\');
+#endif
+    m_file = std::fopen(path.c_str(), "rb");
+    return m_file != nullptr;
+  }
 
   bool OpenFileForWrite(const std::string& filename, bool overwrite = false) { return false; }
 
-  bool IsOpen() const { return false; }
-  void Close() {}
-
-  bool CURLCreate(const std::string& url) { return false; }
-  bool CURLAddOption(CURLOptiontype type, const std::string& name, const std::string& value)
+  bool IsOpen() const { return m_file != nullptr; }
+  void Close()
   {
-    return false;
+    if (m_file)
+    {
+      std::fclose(m_file);
+      m_file = nullptr;
+    }
   }
 
-  bool CURLOpen(unsigned int flags = 0) { return false; }
+  bool CURLCreate(const std::string& url)
+  {
+    auto& state = GetCFileTestState();
+    state.curlCreateCalled = true;
+    return state.curlCreateResult;
+  }
+  bool CURLAddOption(CURLOptiontype type, const std::string& name, const std::string& value)
+  {
+    if (type == ADDON_CURL_OPTION_HEADER)
+      GetCFileTestState().curlHeaders[name] = value;
+    return true;
+  }
 
-  ssize_t Read(void* ptr, size_t size) { return 0; }
+  bool CURLOpen(unsigned int flags = 0)
+  {
+    auto& state = GetCFileTestState();
+    state.curlOpenCalled = true;
+    return state.curlOpenResult;
+  }
+
+  ssize_t Read(void* ptr, size_t size)
+  {
+    ++GetCFileTestState().readCalls;
+    if (!m_file)
+      return -1;
+    const size_t bytesRead = std::fread(ptr, 1, size, m_file);
+    return bytesRead == 0 && std::ferror(m_file) ? -1 : static_cast<ssize_t>(bytesRead);
+  }
 
   bool ReadLine(std::string& line) { return false; }
 
@@ -221,15 +290,59 @@ public:
 
   void Flush() {}
 
-  int64_t Seek(int64_t position, int whence = SEEK_SET) { return 0; }
+  int64_t Seek(int64_t position, int whence = SEEK_SET)
+  {
+    if (GetCFileTestState().failSeek)
+      return -1;
+    if (!m_file)
+      return -1;
+#ifdef _WIN32
+    return _fseeki64(m_file, position, whence) == 0 ? _ftelli64(m_file) : -1;
+#else
+    return fseeko(m_file, position, whence) == 0 ? ftello(m_file) : -1;
+#endif
+  }
 
   int Truncate(int64_t size) { return 0; }
 
-  int64_t GetPosition() const { return 0; }
+  int64_t GetPosition() const
+  {
+    if (!m_file)
+      return -1;
+#ifdef _WIN32
+    return _ftelli64(m_file);
+#else
+    return ftello(m_file);
+#endif
+  }
 
-  int64_t GetLength() const { return 0; }
+  int64_t GetLength() const
+  {
+    if (GetCFileTestState().forceUnknownLength)
+      return -1;
+    const int64_t position = GetPosition();
+    if (position < 0)
+      return -1;
+#ifdef _WIN32
+    if (_fseeki64(m_file, 0, SEEK_END) != 0)
+      return -1;
+    const int64_t length = _ftelli64(m_file);
+    _fseeki64(m_file, position, SEEK_SET);
+#else
+    if (fseeko(m_file, 0, SEEK_END) != 0)
+      return -1;
+    const int64_t length = ftello(m_file);
+    fseeko(m_file, position, SEEK_SET);
+#endif
+    return length;
+  }
 
-  bool AtEnd() const { return true; }
+  bool AtEnd() const
+  {
+    const int64_t position = GetPosition();
+    const int64_t length = GetLength();
+    return position < 0 || length < 0 || position >= length;
+  }
 
   int GetChunkSize() const { return 0; }
 
@@ -243,6 +356,11 @@ public:
 
   const std::string GetPropertyValue(FilePropertyTypes type, const std::string& name) const
   {
+    const auto& state = GetCFileTestState();
+    if (type == ADDON_FILE_PROPERTY_RESPONSE_PROTOCOL)
+      return state.responseProtocol;
+    if (type == ADDON_FILE_PROPERTY_EFFECTIVE_URL)
+      return state.effectiveUrl;
     return "";
   }
 
@@ -253,6 +371,9 @@ public:
   }
 
   double GetFileDownloadSpeed() const { return 0.0; }
+
+private:
+  std::FILE* m_file{nullptr};
 };
 
 inline bool FileExists(const std::string& filename, bool usecache = false)

--- a/src/test/TestChooser.cpp
+++ b/src/test/TestChooser.cpp
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "../common/ChooserDefault.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+class TestRepresentationChooser : public CHOOSER::CRepresentationChooserDefault
+{
+public:
+  void Configure(uint32_t initial, uint32_t minimum, uint32_t maximum)
+  {
+    m_bandwidthInitAuto = true;
+    m_bandwidthInit = initial;
+    m_bandwidthMin = minimum;
+    m_bandwidthMax = maximum;
+  }
+
+  uint32_t CurrentBandwidth() const { return m_bandwidthCurrent; }
+  uint32_t LimitedBandwidth() const { return m_bandwidthCurrentLimited; }
+};
+} // unnamed namespace
+
+TEST(RepresentationChooserTest, IgnoresUnavailableDownloadSpeed)
+{
+  TestRepresentationChooser chooser;
+  chooser.Configure(7000000, 4000000, 5000000);
+
+  chooser.SetDownloadSpeed(0);
+  chooser.PostInit();
+  EXPECT_EQ(chooser.CurrentBandwidth(), 7000000U);
+  EXPECT_EQ(chooser.LimitedBandwidth(), 5000000U);
+
+  chooser.SetDownloadSpeed(0);
+  EXPECT_EQ(chooser.CurrentBandwidth(), 7000000U);
+  EXPECT_EQ(chooser.LimitedBandwidth(), 5000000U);
+}

--- a/src/test/TestCurlUtils.cpp
+++ b/src/test/TestCurlUtils.cpp
@@ -1,0 +1,154 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "../utils/CurlUtils.h"
+#include "../SrvBroker.h"
+
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+
+#include <gtest/gtest.h>
+
+using namespace UTILS;
+
+namespace
+{
+class StubStateGuard
+{
+public:
+  StubStateGuard()
+  {
+    kodi::vfs::ResetCFileTestState();
+    CSrvBroker::GetInstance()->Initialize();
+  }
+  ~StubStateGuard()
+  {
+    CSrvBroker::GetInstance()->Deinitialize();
+    kodi::vfs::ResetCFileTestState();
+  }
+};
+
+std::string GetFixtureUrl()
+{
+  std::filesystem::path path{std::getenv("DATADIR")};
+  path /= "resources/bytes.txt";
+  std::string url{std::filesystem::absolute(path).lexically_normal().generic_string()};
+  return url.starts_with('/') ? "file://" + url : "file:///" + url;
+}
+} // unnamed namespace
+
+TEST(CurlUtilsTest, DownloadsVfsFile)
+{
+  CURL::HTTPResponse response;
+
+  ASSERT_TRUE(CURL::DownloadFile(GetFixtureUrl(), {}, {}, response));
+  EXPECT_EQ(response.data, "0123456789abcdefghijklmnopqrstuvwxyz\n");
+  EXPECT_EQ(response.dataSize, 37U);
+  EXPECT_EQ(response.effectiveUrl, GetFixtureUrl());
+  EXPECT_EQ(response.downloadSpeed, 0.0);
+}
+
+TEST(CurlUtilsTest, ReadsBoundedVfsRange)
+{
+  CURL::CUrl resource{GetFixtureUrl()};
+  resource.SetByteRange(10, 19);
+  ASSERT_EQ(resource.Open(), 200);
+
+  std::string data;
+  EXPECT_EQ(resource.Read(data, 3), CURL::ReadStatus::IS_EOF);
+  EXPECT_EQ(data, "abcdefghij");
+  EXPECT_EQ(resource.GetTotalByteRead(), 10U);
+  EXPECT_TRUE(resource.IsEOF());
+}
+
+TEST(CurlUtilsTest, ReadsOpenEndedVfsRange)
+{
+  CURL::CUrl resource{GetFixtureUrl()};
+  resource.SetByteRange(30);
+  ASSERT_EQ(resource.Open(), 200);
+
+  std::string data;
+  EXPECT_EQ(resource.Read(data), CURL::ReadStatus::IS_EOF);
+  EXPECT_EQ(data, "uvwxyz\n");
+}
+
+TEST(CurlUtilsTest, ReportsEofAfterShortFinalChunk)
+{
+  CURL::CUrl resource{GetFixtureUrl()};
+  ASSERT_EQ(resource.Open(), 200);
+
+  std::array<char, 64> buffer;
+  size_t bytesRead{0};
+  EXPECT_EQ(resource.ReadChunk(buffer.data(), buffer.size(), bytesRead),
+            CURL::ReadStatus::CHUNK_READ);
+  EXPECT_EQ(bytesRead, 37U);
+  EXPECT_TRUE(resource.IsEOF());
+}
+
+TEST(CurlUtilsTest, RejectsMissingVfsFile)
+{
+  CURL::HTTPResponse response;
+  EXPECT_FALSE(CURL::DownloadFile("file:///definitely/not/present/isa-vfs-test", {}, {}, response));
+}
+
+TEST(CurlUtilsTest, ReadsUnknownLengthVfsFileToActualEof)
+{
+  StubStateGuard guard;
+  kodi::vfs::GetCFileTestState().forceUnknownLength = true;
+
+  CURL::CUrl resource{GetFixtureUrl()};
+  ASSERT_EQ(resource.Open(), 200);
+
+  const std::array<std::string, 4> expectedChunks{
+      "0123456789", "abcdefghij", "klmnopqrst", "uvwxyz\n"};
+  std::array<char, 10> buffer;
+  size_t bytesRead{0};
+  for (size_t index = 0; index < expectedChunks.size(); ++index)
+  {
+    EXPECT_EQ(resource.ReadChunk(buffer.data(), buffer.size(), bytesRead),
+              CURL::ReadStatus::CHUNK_READ);
+    EXPECT_EQ(std::string(buffer.data(), bytesRead), expectedChunks[index]);
+    EXPECT_FALSE(resource.IsEOF());
+  }
+  EXPECT_EQ(resource.ReadChunk(buffer.data(), buffer.size(), bytesRead), CURL::ReadStatus::IS_EOF);
+  EXPECT_EQ(bytesRead, 0U);
+  EXPECT_TRUE(resource.IsEOF());
+}
+
+TEST(CurlUtilsTest, PreservesHttpTransportAndRangeHeader)
+{
+  StubStateGuard guard;
+  auto& state = kodi::vfs::GetCFileTestState();
+  state.curlCreateResult = true;
+  state.curlOpenResult = true;
+  state.responseProtocol = "HTTP/1.1 206 Partial Content";
+  state.effectiveUrl = "https://cdn.example/final.m4s";
+
+  CURL::CUrl resource{"https://cdn.example/segment.m4s"};
+  resource.SetByteRange(10, 19);
+
+  EXPECT_EQ(resource.Open(), 206);
+  EXPECT_TRUE(state.curlCreateCalled);
+  EXPECT_TRUE(state.curlOpenCalled);
+  EXPECT_FALSE(state.openFileCalled);
+  EXPECT_EQ(resource.GetEffectiveUrl(), state.effectiveUrl);
+
+  ASSERT_EQ(state.curlHeaders.count("Range"), 1U);
+  EXPECT_EQ(state.curlHeaders.at("Range"), "bytes=10-19");
+}
+
+TEST(CurlUtilsTest, RejectsFailedVfsRangeSeek)
+{
+  StubStateGuard guard;
+  kodi::vfs::GetCFileTestState().failSeek = true;
+
+  CURL::CUrl resource{GetFixtureUrl()};
+  resource.SetByteRange(1);
+  EXPECT_EQ(resource.Open(), -1);
+}

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -14,6 +14,8 @@
 #include "../utils/Utils.h"
 #include "TestHelper.h"
 
+#include <filesystem>
+
 #include <gtest/gtest.h>
 
 using namespace UTILS;
@@ -262,6 +264,53 @@ TEST_F(DASHTreeTest, CalculateBaseURLInRepRangeBytes)
   OpenTestFile("mpd/segmentbase.mpd", "https://foo.bar/test.mpd");
   EXPECT_EQ(tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->GetBaseUrl(),
             "https://foo.bar/video/23.98p/r0/vid10.mp4");
+}
+
+TEST_F(DASHTreeAdaptiveStreamTest, PreparesVfsByteRanges)
+{
+  OpenTestFile("mpd/segmentbase.mpd", "file:///fixtures/test.mpd");
+
+  auto* adaptationSet = tree->m_periods[0]->GetAdaptationSets()[0].get();
+  auto* representation = adaptationSet->GetRepresentations()[0].get();
+  SetTestStream(NewStream(adaptationSet, representation));
+  testStream->SetSegmentFileOffset(1000);
+
+  PLAYLIST::CSegment mediaSegment;
+  mediaSegment.range_begin_ = 10;
+  mediaSegment.range_end_ = 19;
+
+  std::string url;
+  uint64_t rangeBegin;
+  uint64_t rangeEnd;
+  ASSERT_TRUE(
+      testStream->PrepareResource(representation, mediaSegment, url, rangeBegin, rangeEnd));
+  EXPECT_EQ(url, "file:///fixtures/video/23.98p/r0/vid10.mp4");
+  EXPECT_EQ(rangeBegin, 1010U);
+  EXPECT_EQ(rangeEnd, 1019U);
+
+  PLAYLIST::CSegment initSegment;
+  initSegment.SetIsInitialization(true);
+  initSegment.range_begin_ = 20;
+
+  ASSERT_TRUE(testStream->PrepareResource(representation, initSegment, url, rangeBegin, rangeEnd));
+  EXPECT_EQ(rangeBegin, 20U);
+  EXPECT_EQ(rangeEnd, PLAYLIST::NO_VALUE);
+}
+
+TEST_F(DASHTreeAdaptiveStreamTest, DoesNotReadVfsResourceWhenStopped)
+{
+  OpenTestFile("mpd/segmentbase.mpd");
+  auto* adaptationSet = tree->m_periods[0]->GetAdaptationSets()[0].get();
+  SetTestStream(NewStream(adaptationSet));
+
+  std::filesystem::path path{GetEnv("DATADIR")};
+  path /= "resources/bytes.txt";
+  std::string url{std::filesystem::absolute(path).lexically_normal().generic_string()};
+  url.insert(0, url.starts_with('/') ? "file://" : "file:///");
+
+  kodi::vfs::ResetCFileTestState();
+  EXPECT_FALSE(testStream->DownloadStoppedResource(url));
+  EXPECT_EQ(kodi::vfs::GetCFileTestState().readCalls, 0U);
 }
 
 TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTimeline)

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -81,6 +81,32 @@ std::string GetEnv(const std::string& var)
     return val;
 }
 
+bool TestAdaptiveStream::PrepareResource(const PLAYLIST::CRepresentation* rep,
+                                         const PLAYLIST::CSegment& segment,
+                                         std::string& url,
+                                         uint64_t& rangeBegin,
+                                         uint64_t& rangeEnd)
+{
+  DownloadInfo downloadInfo;
+  if (!PrepareDownload(rep, segment, downloadInfo))
+    return false;
+
+  url = downloadInfo.m_url;
+  rangeBegin = downloadInfo.m_rangeBegin;
+  rangeEnd = downloadInfo.m_rangeEnd;
+  return true;
+}
+
+bool TestAdaptiveStream::DownloadStoppedResource(const std::string& url)
+{
+  thread_data_ = new THREADDATA();
+  ADP::SegmentBuffer segmentBuffer;
+  DownloadInfo downloadInfo;
+  downloadInfo.m_url = url;
+  downloadInfo.m_segmentBuffer = &segmentBuffer;
+  return adaptive::AdaptiveStream::DownloadSegment(downloadInfo);
+}
+
 void SetFileName(std::string& file, std::string name)
 {
   file = GetEnv("DATADIR") + "/" + name;

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -62,6 +62,13 @@ public:
   {
   }
 
+  bool PrepareResource(const PLAYLIST::CRepresentation* rep,
+                       const PLAYLIST::CSegment& segment,
+                       std::string& url,
+                       uint64_t& rangeBegin,
+                       uint64_t& rangeEnd);
+  bool DownloadStoppedResource(const std::string& url);
+
   std::chrono::system_clock::time_point mock_time_stream = std::chrono::system_clock::now();
   void SetLastUpdated(const std::chrono::system_clock::time_point tm) override
   {

--- a/src/test/TestUrlUtils.cpp
+++ b/src/test/TestUrlUtils.cpp
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "../utils/UrlUtils.h"
+
+#include <gtest/gtest.h>
+
+using namespace UTILS;
+
+TEST(UrlUtilsTest, DetectsResourceSchemes)
+{
+  EXPECT_TRUE(URL::IsHttpUrl("http://example.test/master.m3u8"));
+  EXPECT_TRUE(URL::IsHttpUrl("HTTPS://example.test/master.m3u8"));
+  EXPECT_FALSE(URL::IsHttpUrl("file:///tmp/master.m3u8"));
+
+  EXPECT_TRUE(URL::IsUrlAbsolute("file:///tmp/master.m3u8"));
+  EXPECT_TRUE(URL::IsUrlAbsolute("special://home/master.m3u8"));
+  EXPECT_TRUE(URL::IsUrlAbsolute("magnet:?xt=urn:btih:abc"));
+  EXPECT_FALSE(URL::IsUrlAbsolute("video/index.m3u8"));
+}
+
+TEST(UrlUtilsTest, ResolvesNestedFileResources)
+{
+  const std::string master{"file:///media/collisions/master.m3u8"};
+  const std::string child{URL::Join(URL::GetUrlPath(master), "video/index.m3u8")};
+
+  EXPECT_EQ(child, "file:///media/collisions/video/index.m3u8");
+  EXPECT_EQ(URL::Join(URL::GetUrlPath(child), "init.mp4"),
+            "file:///media/collisions/video/init.mp4");
+  EXPECT_EQ(URL::Join(URL::GetUrlPath(child), "segment00000.m4s"),
+            "file:///media/collisions/video/segment00000.m4s");
+  EXPECT_EQ(URL::Join(master, "https://cdn.example/child.m3u8"),
+            "https://cdn.example/child.m3u8");
+}
+
+TEST(UrlUtilsTest, PreservesMagnetIdentityAcrossNestedResources)
+{
+  const std::string identity{"?xt=urn:btih:abc&dn=collisions"};
+  const std::string master{"magnet://collisions/master.m3u8" + identity};
+  const std::string child{URL::Join(URL::GetUrlPath(master), "video/index.m3u8")};
+
+  EXPECT_EQ(child, "magnet://collisions/video/index.m3u8" + identity);
+  EXPECT_EQ(URL::Join(URL::GetUrlPath(child), "init.mp4"),
+            "magnet://collisions/video/init.mp4" + identity);
+  EXPECT_EQ(URL::Join(URL::GetUrlPath(child), "segment.m4s?piece=1#part"),
+            "magnet://collisions/video/segment.m4s?piece=1&xt=urn:btih:abc&dn=collisions#part");
+
+  const std::string rootMaster{"magnet://master.m3u8" + identity};
+  EXPECT_EQ(URL::Join(URL::GetUrlPath(rootMaster), "video/index.m3u8"),
+            "magnet://video/index.m3u8" + identity);
+}

--- a/src/test/manifests/resources/bytes.txt
+++ b/src/test/manifests/resources/bytes.txt
@@ -1,0 +1,1 @@
+0123456789abcdefghijklmnopqrstuvwxyz

--- a/src/utils/CurlUtils.cpp
+++ b/src/utils/CurlUtils.cpp
@@ -18,6 +18,9 @@
 #include "CompKodiProps.h"
 #include "SrvBroker.h"
 
+#include <algorithm>
+#include <limits>
+
 using namespace UTILS;
 using namespace UTILS::CURL;
 
@@ -186,7 +189,11 @@ void StoreCookies(const std::string& url, const std::vector<std::string>& cookie
 } // unnamed namespace
 
 UTILS::CURL::CUrl::CUrl(const std::string& url, const RequestType reqType /* = RequestType::AUTO */)
+  : m_url(url), m_isHttp(URL::IsHttpUrl(url))
 {
+  if (!m_isHttp)
+    return;
+
   if (m_file.CURLCreate(url))
   {
     auto& kodiProps = CSrvBroker::GetKodiProps();
@@ -224,7 +231,7 @@ UTILS::CURL::CUrl::CUrl(const std::string& url, const std::string& postData) : C
 
 UTILS::CURL::CUrl::~CUrl()
 {
-  if (CSrvBroker::GetKodiProps().GetConfig().internalCookies)
+  if (m_isHttp && CSrvBroker::GetKodiProps().GetConfig().internalCookies)
     StoreCookies(GetEffectiveUrl(), GetResponseHeaders("set-cookie"));
 
   m_file.Close();
@@ -232,46 +239,95 @@ UTILS::CURL::CUrl::~CUrl()
 
 int UTILS::CURL::CUrl::Open()
 {
-  if (!m_file.CURLOpen(ADDON_READ_NO_CACHE | ADDON_READ_NO_BUFFER))
+  if (m_isHttp)
   {
-    LOG::LogF(LOGERROR, "CURLOpen failed");
+    if (!m_file.CURLOpen(ADDON_READ_NO_CACHE | ADDON_READ_NO_BUFFER))
+    {
+      LOG::LogF(LOGERROR, "CURLOpen failed");
+      return -1;
+    }
+
+    // Get HTTP response status line (e.g. "HTTP/1.1 200 OK")
+    std::string statusLine = m_file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_PROTOCOL, "");
+    if (!statusLine.empty())
+      return STRING::ToInt32(statusLine.substr(statusLine.find(' ') + 1), -1);
+
     return -1;
   }
 
-  // Get HTTP response status line (e.g. "HTTP/1.1 200 OK")
-  std::string statusLine = m_file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_PROTOCOL, "");
-  if (!statusLine.empty())
-    return STRING::ToInt32(statusLine.substr(statusLine.find(' ') + 1), -1);
+  const uint64_t maxOffset{static_cast<uint64_t>(std::numeric_limits<int64_t>::max())};
+  if ((m_rangeBegin && *m_rangeBegin > maxOffset) || (m_rangeEnd && *m_rangeEnd > maxOffset) ||
+      (m_rangeBegin && m_rangeEnd && *m_rangeEnd < *m_rangeBegin))
+  {
+    LOG::Log(LOGERROR, "Cannot open VFS resource, invalid byte range: %s", m_url.c_str());
+    return -1;
+  }
 
-  return -1;
+  if (!m_file.OpenFile(m_url, ADDON_READ_NO_CACHE | ADDON_READ_NO_BUFFER))
+  {
+    LOG::Log(LOGERROR, "Cannot open VFS resource: %s", m_url.c_str());
+    return -1;
+  }
+
+  if (m_rangeBegin && *m_rangeBegin > 0 &&
+      m_file.Seek(static_cast<int64_t>(*m_rangeBegin), SEEK_SET) !=
+          static_cast<int64_t>(*m_rangeBegin))
+  {
+    LOG::Log(LOGERROR, "Cannot seek VFS resource: %s", m_url.c_str());
+    m_file.Close();
+    return -1;
+  }
+
+  m_bytesRead = 0;
+  m_bytesRemaining.reset();
+  m_reachedEof = false;
+  if (m_rangeBegin && m_rangeEnd)
+    m_bytesRemaining = *m_rangeEnd - *m_rangeBegin + 1;
+  m_fileLength = m_file.GetLength();
+  return 200;
 }
 
 void UTILS::CURL::CUrl::AddHeader(const std::string& name, const std::string& value)
 {
-  m_file.CURLAddOption(ADDON_CURL_OPTION_HEADER, name, value);
+  if (m_isHttp)
+    m_file.CURLAddOption(ADDON_CURL_OPTION_HEADER, name, value);
 }
 
 void UTILS::CURL::CUrl::AddHeaders(const std::map<std::string, std::string>& headers)
 {
   for (auto& header : headers)
+    AddHeader(header.first, header.second);
+}
+
+void UTILS::CURL::CUrl::SetByteRange(uint64_t begin, std::optional<uint64_t> end)
+{
+  if (m_isHttp)
   {
-    m_file.CURLAddOption(ADDON_CURL_OPTION_HEADER, header.first, header.second);
+    std::string value{"bytes=" + std::to_string(begin) + "-"};
+    if (end)
+      value += std::to_string(*end);
+    AddHeader("Range", value);
+    return;
   }
+
+  m_rangeBegin = begin;
+  m_rangeEnd = end;
 }
 
 std::string UTILS::CURL::CUrl::GetResponseHeader(const std::string& name)
 {
-  return m_file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_HEADER, name);
+  return m_isHttp ? m_file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_HEADER, name) : "";
 }
 
 std::vector<std::string> UTILS::CURL::CUrl::GetResponseHeaders(const std::string& name)
 {
-  return m_file.GetPropertyValues(ADDON_FILE_PROPERTY_RESPONSE_HEADER, name);
+  return m_isHttp ? m_file.GetPropertyValues(ADDON_FILE_PROPERTY_RESPONSE_HEADER, name)
+                  : std::vector<std::string>{};
 }
 
 std::string UTILS::CURL::CUrl::GetEffectiveUrl()
 {
-  return m_file.GetPropertyValue(ADDON_FILE_PROPERTY_EFFECTIVE_URL, "");
+  return m_isHttp ? m_file.GetPropertyValue(ADDON_FILE_PROPERTY_EFFECTIVE_URL, "") : m_url;
 }
 
 ReadStatus UTILS::CURL::CUrl::Read(std::string& data, size_t chunkBufferSize /* = BUFFER_SIZE_32 */)
@@ -279,38 +335,50 @@ ReadStatus UTILS::CURL::CUrl::Read(std::string& data, size_t chunkBufferSize /* 
   while (true)
   {
     std::vector<char> bufferData(chunkBufferSize);
-    ssize_t ret = m_file.Read(bufferData.data(), chunkBufferSize);
-
-    if (ret == -1)
-      return ReadStatus::ERROR;
-    else if (ret == 0)
-      return ReadStatus::IS_EOF;
-
-    data.append(bufferData.data(), static_cast<size_t>(ret));
-    m_bytesRead += static_cast<size_t>(ret);
+    size_t bytesRead{0};
+    const ReadStatus status = ReadChunk(bufferData.data(), chunkBufferSize, bytesRead);
+    if (status != ReadStatus::CHUNK_READ)
+      return status;
+    data.append(bufferData.data(), bytesRead);
   }
 }
 
 ReadStatus UTILS::CURL::CUrl::ReadChunk(void* buffer, size_t bufferSize, size_t& bytesRead)
 {
-  ssize_t ret = m_file.Read(buffer, bufferSize);
+  bytesRead = 0;
+  if (m_bytesRemaining && *m_bytesRemaining == 0)
+    return ReadStatus::IS_EOF;
+
+  size_t readSize{bufferSize};
+  if (m_bytesRemaining)
+    readSize = static_cast<size_t>(std::min<uint64_t>(*m_bytesRemaining, bufferSize));
+
+  ssize_t ret = m_file.Read(buffer, readSize);
   if (ret == -1)
     return ReadStatus::ERROR;
   else if (ret == 0)
+  {
+    m_reachedEof = true;
     return ReadStatus::IS_EOF;
+  }
 
   bytesRead = static_cast<size_t>(ret);
   m_bytesRead += static_cast<size_t>(ret);
+  if (m_bytesRemaining)
+    *m_bytesRemaining -= bytesRead;
   return ReadStatus::CHUNK_READ;
 }
 
 double UTILS::CURL::CUrl::GetDownloadSpeed()
 {
-  return m_file.GetFileDownloadSpeed();
+  return m_isHttp ? m_file.GetFileDownloadSpeed() : 0.0;
 }
 
 bool UTILS::CURL::CUrl::IsChunked()
 {
+  if (!m_isHttp)
+    return false;
+
   std::string transferEncodingStr{
       m_file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_HEADER, "Transfer-Encoding")};
   std::string contentLengthStr{
@@ -322,6 +390,14 @@ bool UTILS::CURL::CUrl::IsChunked()
 
 bool UTILS::CURL::CUrl::IsEOF()
 {
+  if (m_bytesRemaining && *m_bytesRemaining == 0)
+    return true;
+  if (!m_isHttp)
+  {
+    if (m_fileLength >= 0)
+      return m_file.GetPosition() >= m_fileLength;
+    return m_reachedEof;
+  }
   return m_file.AtEnd();
 }
 

--- a/src/utils/CurlUtils.h
+++ b/src/utils/CurlUtils.h
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <map>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -65,6 +66,7 @@ public:
 
   void AddHeader(const std::string& name, const std::string& value);
   void AddHeaders(const std::map<std::string, std::string>& headers);
+  void SetByteRange(uint64_t begin, std::optional<uint64_t> end = std::nullopt);
 
  /*!
   * \brief Get an header from the HTTP response.
@@ -120,6 +122,13 @@ public:
 
 private:
   kodi::vfs::CFile m_file;
+  std::string m_url;
+  bool m_isHttp{false};
+  std::optional<uint64_t> m_rangeBegin;
+  std::optional<uint64_t> m_rangeEnd;
+  std::optional<uint64_t> m_bytesRemaining;
+  int64_t m_fileLength{-1};
+  bool m_reachedEof{false};
   size_t m_bytesRead{0};
 };
 

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -12,12 +12,79 @@
 #include "StringUtils.h"
 #include "log.h"
 
+#include <cctype>
+
 using namespace UTILS;
 
 namespace
 {
 constexpr std::string_view PREFIX_SINGLE_DOT{"./"};
 constexpr std::string_view PREFIX_DOUBLE_DOT{"../"};
+
+size_t GetSchemeSeparator(std::string_view url)
+{
+  if (url.empty() || !std::isalpha(static_cast<unsigned char>(url.front())))
+    return std::string_view::npos;
+
+  for (size_t pos = 1; pos < url.size(); ++pos)
+  {
+    const unsigned char value = static_cast<unsigned char>(url[pos]);
+    if (url[pos] == ':')
+      return pos;
+    if (!std::isalnum(value) && url[pos] != '+' && url[pos] != '-' && url[pos] != '.')
+      return std::string_view::npos;
+  }
+  return std::string_view::npos;
+}
+
+bool IsScheme(std::string_view url, std::string_view scheme)
+{
+  const size_t separator = GetSchemeSeparator(url);
+  return separator == scheme.size() && STRING::CompareNoCase(url.substr(0, separator), scheme);
+}
+
+bool IsMagnetUrl(std::string_view url)
+{
+  return IsScheme(url, "magnet");
+}
+
+size_t GetPathStart(std::string_view url)
+{
+  const size_t schemeSeparator = GetSchemeSeparator(url);
+  if (schemeSeparator == std::string_view::npos)
+    return 0;
+
+  if (IsMagnetUrl(url))
+  {
+    const size_t pathStart = url.find_first_not_of('/', schemeSeparator + 1);
+    return pathStart == std::string_view::npos ? url.size() : pathStart;
+  }
+
+  if (url.substr(schemeSeparator + 1).starts_with("//"))
+  {
+    const size_t pathStart = url.find('/', schemeSeparator + 3);
+    return pathStart == std::string_view::npos ? url.size() : pathStart;
+  }
+  return schemeSeparator + 1;
+}
+
+void RemoveFragment(std::string& url)
+{
+  const size_t fragmentPos = url.find('#');
+  if (fragmentPos != std::string::npos)
+    url.erase(fragmentPos);
+}
+
+std::string RemoveQuery(std::string& url)
+{
+  const size_t queryPos = url.find('?');
+  if (queryPos == std::string::npos)
+    return {};
+
+  std::string query{url.substr(queryPos)};
+  url.erase(queryPos);
+  return query;
+}
 
 bool isUrl(std::string url,
            bool allowFragments,
@@ -106,6 +173,9 @@ void RemovePrefixDoubleDot(std::string& url)
  */
 std::string RemoveDotSegments(std::string url)
 {
+  if (url.size() < 2)
+    return url;
+
   // Count amount of special prefixes with double dots on the right side
   size_t numSegsRemove{0};
   size_t currPos{0};
@@ -123,19 +193,21 @@ std::string RemoveDotSegments(std::string url)
   RemovePrefixSingleDot(url);
   RemovePrefixDoubleDot(url);
 
-  size_t addrsStartPos{0};
-  if (URL::IsUrlAbsolute(url))
-    addrsStartPos = url.find("://") + 3;
+  const size_t pathStart = GetPathStart(url);
+  size_t pathRootEnd{0};
+  if (GetSchemeSeparator(url) != std::string_view::npos)
+    pathRootEnd = pathStart < url.size() && url[pathStart] == '/' ? pathStart + 1 : pathStart;
   else if (URL::IsUrlRelativeLevel(url))
-    addrsStartPos = 3;
+    pathRootEnd = 3;
 
   // Remove segments from the end (if any)
   for (; numSegsRemove > 0; numSegsRemove--)
   {
     std::size_t lastSlashPos = url.find_last_of('/', url.size() - 2);
-    if ((lastSlashPos + 1) == addrsStartPos)
-      break;
-    url = url.substr(0, lastSlashPos + 1);
+    if (lastSlashPos == std::string::npos || lastSlashPos + 1 < pathRootEnd)
+      url.resize(pathRootEnd);
+    else
+      url.resize(lastSlashPos + 1);
   }
 
   return url;
@@ -148,9 +220,16 @@ bool UTILS::URL::IsValidUrl(const std::string& url)
   return isUrl(url, false, true, true, true, true, false);
 }
 
+bool UTILS::URL::IsHttpUrl(std::string_view url)
+{
+  const size_t separator = GetSchemeSeparator(url);
+  return (IsScheme(url, "http") || IsScheme(url, "https")) &&
+         url.substr(separator + 1).starts_with("//");
+}
+
 bool UTILS::URL::IsUrlAbsolute(std::string_view url)
 {
-  return (url.compare(0, 7, "http://") == 0 || url.compare(0, 8, "https://") == 0);
+  return GetSchemeSeparator(url) != std::string_view::npos;
 }
 
 bool UTILS::URL::IsUrlRelative(std::string_view url)
@@ -210,19 +289,28 @@ std::string UTILS::URL::GetUrlPath(std::string url)
   if (url.empty())
     return url;
 
-  size_t paramsPos = url.find('?');
-  if (paramsPos != std::string::npos)
-    url.resize(paramsPos);
+  const bool preserveQuery = IsMagnetUrl(url);
+  RemoveFragment(url);
+  std::string query = RemoveQuery(url);
+  if (!preserveQuery)
+    query.clear();
+
+  const size_t schemeSeparator = GetSchemeSeparator(url);
+  const size_t pathStart = GetPathStart(url);
 
   // The part of the base url after last / is not a directory so will not be taken into account
-  if (url.back() != '/')
+  if (!url.empty() && url.back() != '/')
   {
-    size_t slashPos = url.rfind("/");
-    if (slashPos > url.find("://") + 3)
+    const size_t slashPos = url.rfind('/');
+    if (slashPos != std::string::npos && slashPos >= pathStart)
       url.erase(slashPos + 1);
+    else if (schemeSeparator != std::string::npos)
+      url.erase(pathStart);
+    else
+      url.clear();
   }
 
-  return url;
+  return url + query;
 }
 
 void UTILS::URL::AppendParameters(std::string& url, std::string_view params)
@@ -287,6 +375,15 @@ std::string UTILS::URL::Join(std::string baseUrl, std::string relativeUrl)
   if (relativeUrl.empty())
     return baseUrl;
 
+  if (IsUrlAbsolute(relativeUrl))
+    return relativeUrl;
+
+  const bool inheritBaseQuery = IsMagnetUrl(baseUrl);
+  RemoveFragment(baseUrl);
+  std::string baseQuery = RemoveQuery(baseUrl);
+  if (!inheritBaseQuery)
+    baseQuery.clear();
+
   if (relativeUrl == ".") // Ignore single dot
     relativeUrl.clear();
 
@@ -295,14 +392,19 @@ std::string UTILS::URL::Join(std::string baseUrl, std::string relativeUrl)
     relativeUrl += "/";
 
   // The part of the base url after last / is not a directory so will not be taken into account
-  if (baseUrl.back() != '/')
+  if (!baseUrl.empty() && baseUrl.back() != '/')
   {
-    size_t slashPos = baseUrl.rfind("/");
-    if (slashPos > baseUrl.find("://") + 3)
+    const size_t pathStart = GetPathStart(baseUrl);
+    const size_t slashPos = baseUrl.rfind('/');
+    if (slashPos != std::string::npos && slashPos >= pathStart)
       baseUrl.erase(slashPos + 1);
+    else if (GetSchemeSeparator(baseUrl) != std::string_view::npos)
+      baseUrl.erase(pathStart);
+    else
+      baseUrl.clear();
   }
 
-  if (baseUrl.back() != '/')
+  if (!baseUrl.empty() && baseUrl.back() != '/')
     baseUrl += "/";
 
   bool skipRemovingSegs{true};
@@ -337,7 +439,17 @@ std::string UTILS::URL::Join(std::string baseUrl, std::string relativeUrl)
     relativeUrl.erase(0, startPos);
   }
 
-  return RemoveDotSegments(baseUrl + relativeUrl);
+  std::string result = RemoveDotSegments(baseUrl + relativeUrl);
+  if (baseQuery.size() > 1)
+  {
+    const size_t fragmentPos = result.find('#');
+    const size_t queryPos = result.find('?');
+    if (queryPos != std::string::npos &&
+        (fragmentPos == std::string::npos || queryPos < fragmentPos))
+      baseQuery.front() = '&';
+    result.insert(fragmentPos == std::string::npos ? result.size() : fragmentPos, baseQuery);
+  }
+  return result;
 }
 
 void UTILS::URL::EnsureEndingBackslash(std::string& url)

--- a/src/utils/UrlUtils.h
+++ b/src/utils/UrlUtils.h
@@ -22,6 +22,9 @@ namespace URL
  */
 bool IsValidUrl(const std::string& url);
 
+/*! \brief Check if an URL uses the HTTP or HTTPS scheme. */
+bool IsHttpUrl(std::string_view url);
+
 /*! \brief Check if it is an absolute URL
  *  \return True if it is an absolute URL, false otherwise
  */


### PR DESCRIPTION
## Description

Allow adaptive resources to be read through Kodi's VFS in addition to HTTP(S). Because I want to play `file:://` URLs.

AI use:

Extend URL resolution to support Kodi VFS schemes, including `file://` URLs and URNs (such as potential v23 `magnet:` links in https://github.com/xbmc/xbmc/pull/23696) across nested playlist, init and segment URLs.

Extend `CUrl` so HTTP(S) keeps the existing CURL path while other schemes use `kodi::vfs::CFile`. Byte ranges use the existing HTTP `Range` header for HTTP(S), or seek and bounded reads for VFS resources.

Update adaptive segment downloads to use the transport-independent range handling.

## Motivation and context

InputStream Adaptive currently opens adaptive resources through Kodi's CURL interface, which limits playback to HTTP(S)-style resources.

This allows manifests and their referenced resources to be loaded from Kodi VFS URLs such as `file://`, and enables VFS providers such as Kodi's `magnet:` filesystem to be used by InputStream Adaptive without adding transport-specific code to the add-on.

## How has this been tested?

Tested on macOS ARM64 with Kodi 22 development builds.

- Added tests for generic URI detection and nested VFS URL resolution, including preservation of magnet query identity.
- Added tests for local VFS reads, bounded and open-ended byte ranges, EOF handling, failed seeks, and preservation of the existing HTTP path.
- Added adaptive-stream tests for VFS byte ranges and stopped downloads.
- Full InputStream Adaptive test suite passes: 83/83.
- Tested end-to-end with a local CMAF/HLS presentation using `file://`.
- Kodi loaded the modified InputStream Adaptive add-on, opened the master and child playlists, initialization fragments and media segments, decoded 3840x2160 H.264 with E-AC-3 Atmos audio, and played the approximately 20-second presentation to normal EOF.

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
